### PR TITLE
added a small change to manifest, as on Firefox

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -21,5 +21,9 @@
     "default_popup": "popup.html"
   },
   "manifest_version": 3,
-  "version": "0.0.17"
+  "version": "0.0.17",
+
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self';"
+  }
 }


### PR DESCRIPTION
the addon did not work on firefox. the modification
tells to firefox to not to switch to https the requests from the extension